### PR TITLE
Add Stack support and upgrade to lts-3.16.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.stack-work

--- a/cereal-plus.cabal
+++ b/cereal-plus.cabal
@@ -5,20 +5,20 @@ version:
 synopsis:
   An extended serialization library on top of "cereal"
 description:
-  Provides non-orphan instances for an extended range of types, 
+  Provides non-orphan instances for an extended range of types,
   transformer types and support for mutable data,
   while reapproaching the naming conventions of \"cereal\" library.
 
-  For a streaming frontend over this library see 
+  For a streaming frontend over this library see
   <http://hackage.haskell.org/package/pipes-cereal-plus "pipes-cereal-plus">
 license:
   MIT
 license-file:
   LICENSE
 homepage:
-  https://github.com/nikita-volkov/cereal-plus 
+  https://github.com/nikita-volkov/cereal-plus
 bug-reports:
-  https://github.com/nikita-volkov/cereal-plus/issues 
+  https://github.com/nikita-volkov/cereal-plus/issues
 author:
   Nikita Volkov <nikita.y.volkov@mail.ru>
 maintainer:
@@ -51,7 +51,7 @@ library
     CerealPlus.Prelude
   build-depends:
     -- Serialization:
-    cereal == 0.4.*,
+    cereal,
     -- Concurrency:
     stm,
     -- Data:
@@ -65,10 +65,10 @@ library
     text,
     bytestring,
     -- Control:
-    mmorph == 1.0.*,
-    errors == 1.4.*,
-    mtl >= 2 && < 2.3,
-    base >= 4.5 && < 4.8
+    mmorph,
+    errors,
+    mtl,
+    base
   ghc-options:
     -funbox-strict-fields
   default-extensions:
@@ -78,11 +78,11 @@ library
 
 
 test-suite cereal-plus-htf-test-suite
-  type:             
+  type:
     exitcode-stdio-1.0
-  hs-source-dirs:   
+  hs-source-dirs:
     htf-test-suite
-  main-is:          
+  main-is:
     HTFTestSuite.hs
   build-depends:
     cereal-plus,
@@ -90,7 +90,7 @@ test-suite cereal-plus-htf-test-suite
     quickcheck-instances,
     QuickCheck,
     HUnit,
-    HTF == 0.12.*,
+    HTF,
     -- Serialization:
     cereal,
     -- Concurrency:

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,32 @@
+# For more information, see: https://github.com/commercialhaskell/stack/blob/release/doc/yaml_configuration.md
+
+# Specifies the GHC version and set of packages available (e.g., lts-3.5, nightly-2015-09-21, ghc-7.10.2)
+resolver: lts-3.17
+
+# Local packages, usually specified by relative directory name
+packages:
+- '.'
+
+# Packages to be pulled from upstream that are not in the resolver (e.g., acme-missiles-0.3)
+extra-deps: []
+
+# Override default flag values for local packages and extra-deps
+flags: {}
+
+# Extra package databases containing global packages
+extra-package-dbs: []
+
+# Control whether we use the GHC we find on the path
+# system-ghc: true
+
+# Require a specific version of stack, using version ranges
+# require-stack-version: -any # Default
+# require-stack-version: >= 0.1.4.0
+
+# Override the architecture used by stack, especially useful on Windows
+# arch: i386
+# arch: x86_64
+
+# Extra directories used by stack for building
+# extra-include-dirs: [/path/to/dir]
+# extra-lib-dirs: [/path/to/dir]


### PR DESCRIPTION
Certain dependencies (most notably HTF) were limiting it to lts-2.22. My preferred way to deal with this is to remove all constraints in the .cabal file and let stack deal with dependencies, but if you'd like me to restore some of the dependencies, let me know.
