### PR TITLE
Bump HTF version to 0.13.

### DIFF
--- a/cereal-plus.cabal
+++ b/cereal-plus.cabal
@@ -1,7 +1,7 @@
 name:
   cereal-plus
 version:
-  0.4.0
+  0.4.1
 synopsis:
   An extended serialization library on top of "cereal"
 description:
@@ -66,9 +66,9 @@ library
     bytestring,
     -- Control:
     mmorph == 1.0.*,
-    errors == 1.4.*,
+    errors >= 1.4 && < 2.1,
     mtl >= 2 && < 2.3,
-    base >= 4.5 && < 4.8
+    base >= 4.5 && < 4.9
   ghc-options:
     -funbox-strict-fields
   default-extensions:
@@ -90,7 +90,7 @@ test-suite cereal-plus-htf-test-suite
     quickcheck-instances,
     QuickCheck,
     HUnit,
-    HTF == 0.12.*,
+    HTF == 0.13.*,
     -- Serialization:
     cereal,
     -- Concurrency:


### PR DESCRIPTION
I specified 0.14 specifically, but I could also do `>= 0.13 && < 0.15` instead. Your call.

This also relaxes `errors` and `base` bounds (as conservatively as possible) so that the package will Just Work with lts-3.17 (though the package itself remains stack-agnostic). I think it likely that this release will continue to work up for all the 3.\* LTS releases.

I bumped the .patch version (as recommended by server); again, let me know if you'd rather not do that now, and I'll take it out.

All tests continue to pass.
